### PR TITLE
set the movie title to black to be able to see on white background

### DIFF
--- a/MVPSample/app/src/main/res/layout/list_row_movie.xml
+++ b/MVPSample/app/src/main/res/layout/list_row_movie.xml
@@ -30,7 +30,7 @@
             android:id="@+id/movie_title_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/white"
+            android:textColor="@android:color/black"
             android:textSize="20sp"
             android:textStyle="bold|italic"
             android:fontFamily="sans-serif"


### PR DESCRIPTION
The background colour for the card layout is white so the movie title text was not visible as it was also set to white. I have changed the colour of the text for the movie background to black.